### PR TITLE
* 解决 RTL 布局下内容页面的视图会水平翻转的问题

### DIFF
--- a/Sources/Common/JXCategoryListContainerView.m
+++ b/Sources/Common/JXCategoryListContainerView.m
@@ -228,6 +228,11 @@
         }
         [cell.contentView addSubview:[list listView]];
     }
+    // 针对 RTL 布局
+    if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute]
+        == UIUserInterfaceLayoutDirectionRightToLeft) {
+        cell.contentView.transform = CGAffineTransformMakeScale(-1, 1);
+    }
     return cell;
 }
 


### PR DESCRIPTION
在JXCategoryListContainerView类里判断是否 RTL布局，然后对 cell.contentView. transform 做一次水平翻转