### PR TITLE
解决当categoryTitleImageView 放在导航栏中点击会被StackView影响的问题

### DIFF
--- a/Sources/TitleImage/JXCategoryTitleImageCell.m
+++ b/Sources/TitleImage/JXCategoryTitleImageCell.m
@@ -42,6 +42,7 @@
     self.imageViewHeightConstraint.active = YES;
 
     _stackView = [[UIStackView alloc] init];
+    _stackView.userInteractionEnabled = NO;
     self.stackView.alignment = UIStackViewAlignmentCenter;
     [self.contentView addSubview:self.stackView];
     self.stackView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
当categoryTitleImageView 放在导航栏中点击会被StackView影响的问题
```
_stackView.userInteractionEnabled = NO;
```